### PR TITLE
Enforce buffer 5.2.1 using yarn package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1"
   },
+  "resolutions": {
+    "**/buffer": "5.2.1"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2214,16 +2214,7 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@^4.3.0:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
-  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-    isarray "^1.0.0"
-
-buffer@^5.2.1:
+buffer@5.2.1, buffer@^4.3.0, buffer@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
   integrity sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==


### PR DESCRIPTION
Addressing issue: #1: Error parsing some audio files with music-metadata-browser

Added the following to package.json:
```json
"resolutions": {
    "**/buffer": "5.2.1"
  }
```

Reference: https://yarnpkg.com/lang/en/docs/selective-version-resolutions

You can figure out where buffer is used using:
```shell
yarn why buffer
```

You need to run ``yarn install`` after adding the resolutions, to update the targetted dependencies.