### PR TITLE
#1 Update music-metadata-browser to 1.2.2, which has workaround for b…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "music-metadata-browser": "^1.2.1",
+    "music-metadata-browser": "^1.2.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3933,10 +3933,10 @@ file-loader@3.0.1:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
 
-file-type@^11.0.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-11.1.0.tgz#93780f3fed98b599755d846b99a1617a2ad063b8"
-  integrity sha512-rM0UO7Qm9K7TWTtA6AShI/t7H5BPjDeGVDaNyg9BjHAj3PysKy7+8C8D137R88jnR3rFJZQB/tFgydl5sN5m7g==
+file-type@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-12.1.0.tgz#c2938e303bd0f0b96cd98f0f47d7c114de592350"
+  integrity sha512-aZkf42yWGiH+vSOpbVgvbnoRuX4JiitMX9pHYqTHemNQ3lrx64iHi33YGAP7TSJSno56kxQY1lHmw8S6ujlFUg==
 
 filesize@3.6.1:
   version "3.6.1"
@@ -6259,28 +6259,28 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
-music-metadata-browser@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/music-metadata-browser/-/music-metadata-browser-1.2.1.tgz#43b0b6590bf445fe273190585aad4f442095ab7e"
-  integrity sha512-CMfHyeAa8t66nP66xYNNwvynIw/YZ3GSmotjSccI/wUYgmcLlnUkbLOTsuAB6SS9/d30jl4M35FUegpC0KgTEA==
+music-metadata-browser@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/music-metadata-browser/-/music-metadata-browser-1.2.2.tgz#e94356883e7fa7f05e86d679ba4dcadad8226d4e"
+  integrity sha512-UXB2XON67nMJ61RDul+LxbQBpKC/1uKxwV8g7jDqNsfnH1rm+Am+JJqPu8dtzPRTvcJBi+/MO2CWnQL35+sgwA==
   dependencies:
     assert "^2.0.0"
     buffer "^5.2.1"
     debug "^4.0.1"
-    music-metadata "^4.2.0"
+    music-metadata "^4.2.3"
     readable-stream "^3.3.0"
     readable-web-to-node-stream "^1.1.4"
     remove "^0.1.5"
     typedarray-to-buffer "^3.1.5"
 
-music-metadata@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/music-metadata/-/music-metadata-4.2.1.tgz#5f1d6ca0c9e5a9d0be51a94be1cf9a991ca69ee0"
-  integrity sha512-+82UydNm/EVoazeRR7YhRGHNNqbPXDsI0O7/2gyk+o+jrAVBZclEM33rdl6BbikEFpWTOxhZW3EZkVQtiGDeTg==
+music-metadata@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/music-metadata/-/music-metadata-4.2.3.tgz#a31fcdf8573b9794ad81ef6be16224d3e1815b36"
+  integrity sha512-lA1Z5tEAn/hgbQnJp1G7TfLrGH3fYB5R5oNfDTn56IiE3GAwgQ0xn95CjJSalW+Kw4t1b0HzPf/AyMEAmje1zQ==
   dependencies:
     content-type "^1.0.4"
     debug "^4.1.0"
-    file-type "^11.0.0"
+    file-type "^12.1.0"
     media-typer "^1.1.0"
     strtok3 "^3.0.0"
     token-types "^1.0.1"


### PR DESCRIPTION
Address issue #1, Borewit/music-metadata-browser#28

Update music-metadata-browser to 1.2.2, which has workaround for buffer v4 compatibility.

Superseed PR: #2